### PR TITLE
Prisma type conversion upon bot integration creation

### DIFF
--- a/server/src/integration/discord.ts
+++ b/server/src/integration/discord.ts
@@ -117,9 +117,14 @@ export default class DiscordBot {
             chat_id,
           );
 
+          if (typeof bot_response == "string") {
+            console.error(bot_response);
+            return;
+          }
+
           const unique_button_sources: Array<string> = Array.from(
             // Convert to Set so we only get unique sources
-            // i.e. sources made from the same source will be "merged"
+            // i.e. text from the same url will be "merged"
             new Set(
               bot_response?.sourceDocuments?.map(
                 (d: { metadata: { source: string } }): string =>

--- a/server/src/routes/api/v1/bot/integration/handlers/post.handler.ts
+++ b/server/src/routes/api/v1/bot/integration/handlers/post.handler.ts
@@ -168,8 +168,12 @@ export const createIntergationHandler = async (
             discord_slash_command: request.body.value.discord_slash_command,
             discord_slash_command_description:
               request.body.value.discord_slash_command_description,
-            discord_show_sources: request.body.value.discord_show_sources,
-            discord_smart_label: request.body.value.discord_smart_label,
+            discord_show_sources:
+              !!request.body.value.discord_show_sources &&
+              request.body.value.discord_show_sources != "false",
+            discord_smart_label:
+              !!request.body.value.discord_smart_label &&
+              request.body.value.discord_smart_label != "false",
             identifier: process_name_dc,
           },
         });


### PR DESCRIPTION
I realised that I was not converting the string to bool upon bot creation in prisma so I've updated that code here. I missed this as I have not actually tried to use the code from "fresh" .

Also this spawned a new type-error highligting a problem with errors returned from discord bot handler - so I fixed that too. Sorry for not catching this in the previous pull request.