### PR TITLE
fix(security): confine /api/v1/view/* reads to uploads dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dialoqbase",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "description": "Create chatbots with ease",
   "scripts": {
     "ui:dev": "pnpm run --filter ui dev",

--- a/server/src/routes/api/v1/view/root.ts
+++ b/server/src/routes/api/v1/view/root.ts
@@ -1,6 +1,11 @@
 import { FastifyPluginAsync } from "fastify";
 import * as fs from "fs/promises";
-import { join } from "path";
+import { resolve, sep } from "path";
+
+// All user-uploaded assets are written to `./uploads/` relative to the
+// process working directory (see upload.handler.ts). Confine every read to
+// that directory so a wildcard like `../../../etc/passwd` cannot escape it.
+const UPLOADS_DIR = resolve(process.cwd(), "uploads");
 
 const root: FastifyPluginAsync = async (fastify, _): Promise<void> => {
   fastify.get(
@@ -13,10 +18,23 @@ const root: FastifyPluginAsync = async (fastify, _): Promise<void> => {
     async (request, reply) => {
       try {
         //@ts-ignore
-        const filePath = request.params["*"];
-        const path = join(__dirname, `../../../../../${filePath}`);
+        const filePath: string = request.params["*"] || "";
+
+        // Strip any leading reference to the uploads dir the client may send
+        // (e.g. "uploads/x", "./uploads/x" or "app/uploads/x") so the path is
+        // always resolved relative to UPLOADS_DIR.
+        const requested = filePath.replace(/^(\.\/)?(app\/)?uploads\//, "");
+
+        // Resolve and ensure the result stays inside UPLOADS_DIR. resolve()
+        // collapses any `..` segments, so the prefix check below rejects every
+        // traversal attempt.
+        const path = resolve(UPLOADS_DIR, requested);
+        if (path !== UPLOADS_DIR && !path.startsWith(UPLOADS_DIR + sep)) {
+          return reply.status(404).send("Not Found");
+        }
+
         const file = await fs.readFile(path);
-        const ext = filePath.split(".").pop();
+        const ext = requested.split(".").pop();
         // set content type
         if (ext === "pdf") {
           reply.header("Content-Type", "application/pdf");


### PR DESCRIPTION
## Summary

The `GET /api/v1/view/*` route resolved the attacker-controlled wildcard against the filesystem with no normalization or containment, so requests could read files outside the intended assets directory. It is also reachable without authentication.

This confines every read to the uploads directory (`process.cwd()/uploads`, where the app writes uploaded sources) and returns `404` for anything that resolves outside it. `resolve()` collapses `..` segments, and a prefix check rejects escapes.

## Changes
- `server/src/routes/api/v1/view/root.ts` — resolve requests under `UPLOADS_DIR` and reject paths outside it.
- Version bump `1.11.4` → `1.11.5`.

## Verification
- `tsc --noEmit` clean.
- Legitimate `uploads/<uuid>-file.pdf` paths still serve; traversal payloads resolve outside `uploads/` and return 404.

## Post-merge follow-ups
- **Rotate `DB_SECRET_KEY`** in production (must be treated as potentially exposed; invalidates existing sessions).
- Consider requiring auth on this route if served assets are not meant to be public.
- Tag `v1.11.5` to trigger the Docker image release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)